### PR TITLE
Get only values for mapped properties in Update<T>

### DIFF
--- a/DapperExtensions.Test/ReflectionHelperFixture.cs
+++ b/DapperExtensions.Test/ReflectionHelperFixture.cs
@@ -26,7 +26,7 @@ namespace DapperExtensions.Test
         {
             Foo f = new Foo { Bar = 3, Baz = "Yum" };
 
-            var dictionary = ReflectionHelper.GetObjectValues(f);
+            var dictionary = ReflectionHelper.GetObjectValues(f, null);
             Assert.AreEqual(3, dictionary["Bar"]);
             Assert.AreEqual("Yum", dictionary["Baz"]);
         }
@@ -34,7 +34,7 @@ namespace DapperExtensions.Test
         [Test]
         public void GetObjectValues_Returns_Empty_Dictionary_When_Null_Object_Provided()
         {
-            var dictionary = ReflectionHelper.GetObjectValues(null);
+            var dictionary = ReflectionHelper.GetObjectValues(null, null);
             Assert.AreEqual(0, dictionary.Count);
         }
     }

--- a/DapperExtensions/DapperImplementor.cs
+++ b/DapperExtensions/DapperImplementor.cs
@@ -127,9 +127,10 @@ namespace DapperExtensions
             DynamicParameters dynamicParameters = new DynamicParameters();
 
             var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity));
-            foreach (var property in ReflectionHelper.GetObjectValues(entity).Where(property => columns.Any(c => c.Name == property.Key)))
+            foreach (var property in ReflectionHelper.GetObjectValues(entity, columns))
             {
-                dynamicParameters.Add(property.Key, property.Value);
+                DbType type = columns.Where(column => column.Name == property.Key).Select(column => column.Type).First();
+                dynamicParameters.Add(property.Key, property.Value, dbType: type);
             }
 
             foreach (var parameter in parameters)
@@ -251,7 +252,7 @@ namespace DapperExtensions
             IList<IPredicate> predicates = new List<IPredicate>();
             if (!isSimpleType)
             {
-                paramValues = ReflectionHelper.GetObjectValues(id);
+                paramValues = ReflectionHelper.GetObjectValues(id, classMap.Properties);
             }
 
             foreach (var key in keys)
@@ -311,7 +312,7 @@ namespace DapperExtensions
         {
             Type predicateType = typeof(FieldPredicate<>).MakeGenericType(classMap.EntityType);
             IList<IPredicate> predicates = new List<IPredicate>();
-            foreach (var kvp in ReflectionHelper.GetObjectValues(entity))
+            foreach (var kvp in ReflectionHelper.GetObjectValues(entity, classMap.Properties))
             {
                 IFieldPredicate fieldPredicate = Activator.CreateInstance(predicateType) as IFieldPredicate;
                 fieldPredicate.Not = false;

--- a/DapperExtensions/ReflectionHelper.cs
+++ b/DapperExtensions/ReflectionHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using DapperExtensions.Mapper;
 
 namespace DapperExtensions
 {
@@ -54,7 +55,7 @@ namespace DapperExtensions
             }
         }
 
-        public static IDictionary<string, object> GetObjectValues(object obj)
+        public static IDictionary<string, object> GetObjectValues(object obj, IEnumerable<IPropertyMap> mappedColumns)
         {
             IDictionary<string, object> result = new Dictionary<string, object>();
             if (obj == null)
@@ -66,8 +67,11 @@ namespace DapperExtensions
             foreach (var propertyInfo in obj.GetType().GetProperties())
             {
                 string name = propertyInfo.Name;
-                object value = propertyInfo.GetValue(obj, null);
-                result[name] = value;
+                if (mappedColumns == null || mappedColumns.Any(property => property.Name == name))
+                {
+                    object value = propertyInfo.GetValue(obj, null);
+                    result[name] = value;
+                }
             }
 
             return result;


### PR DESCRIPTION
If a column is ignored by mapper don't try to get a value when updating. The getter can be doing db interaction which can cause problems with transactions.
